### PR TITLE
Make the upload location configurable (default "svg")

### DIFF
--- a/wagtailsvg/models.py
+++ b/wagtailsvg/models.py
@@ -1,7 +1,8 @@
 import os
 from io import BytesIO
 from taggit.managers import TaggableManager
-from django.core.files.storage import default_storage
+from django.conf import settings
+from django.core.files.storage import default_storage, FileSystemStorage
 from django.core.files.images import ImageFile
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -11,13 +12,14 @@ from wagtail.search import index
 from wagtail.admin.edit_handlers import ObjectList
 from wagtail.admin.edit_handlers import FieldPanel
 
-
 # from wagtailsvg.edit_handlers import EditCodePanel
 
 
 class Svg(CollectionMember, index.Indexed, models.Model):
+    upload_directory = 'svg'
+    storage = FileSystemStorage(location=settings.MEDIA_ROOT, base_url=settings.MEDIA_URL)
     title = models.CharField(max_length=255, verbose_name=_("title"))
-    file = models.FileField(upload_to="media", verbose_name=_("file"))
+    file = models.FileField(upload_to=upload_directory, verbose_name=_("file"), storage=storage)
     tags = TaggableManager(help_text=None, blank=True, verbose_name=_("tags"))
     edit_code = models.TextField(default='', blank=True)
 


### PR DESCRIPTION
The default location for media uploads was "media", which put the location as MEDIA_ROOT/media (usually /media/media/file.svg). This patch does the following:
- Makes the default directory configurable (override the class variable in a subclass)
- Makes the default directory "svg" (so "file.svg" ends up by default in MEDIA_ROOT/svg/file.svg)
- Allows the storage location to be overridden in a subclass (so as to upload to /favicons instead of MEDIA_ROOT, for example)