### PR TITLE
add apps.py to set the default_auto_field value for the app

### DIFF
--- a/wagtailsvg/apps.py
+++ b/wagtailsvg/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class WagtailsvgConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
+    name = 'wagtailsvg'


### PR DESCRIPTION
Currently, using this app with Django 3.2 issues the following warning every time a manage.py command (migrate, runserver...) is run :

```
WARNINGS:
wagtailsvg.Svg: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```
I added the apps.py file with the default_auto_field to remove that warning.

It also solves issue https://github.com/Aleksi44/wagtailsvg/issues/9