### PR TITLE
HTML escape SvgChooserBlock output

### DIFF
--- a/wagtailsvg/blocks.py
+++ b/wagtailsvg/blocks.py
@@ -1,4 +1,5 @@
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from wagtail.core.blocks import ChooserBlock
 
 
@@ -14,10 +15,10 @@ class SvgChooserBlock(ChooserBlock):
         return AdminSvgChooser()
 
     def render_basic(self, value, context=None):
-        return "<img src='%s' alt='%s'>" % (
-            value.url,
-            value.title
-        )
+        if value:
+            return format_html("<img src='{0}' alt='{1}'>", value.url, value.title)
+        else:
+            return ''
 
     def get_form_state(self, value):
         value_data = self.widget.get_value_data(value)


### PR DESCRIPTION
With this change in wagtail https://github.com/wagtail/wagtail/commit/c564c2949460557cde58207ddc34eb4807eeede2, which constituted wagtail versions 2.11.8, 2.12.5 and 2.13.2 (here is a release note for 2.13.2 https://github.com/wagtail/wagtail/commit/74e3c1764f059fdbf98ffd92b774ad5e6c19dc68), the complete SvgChooserBlock output is escaped when rendered and thus instead of an expected image one would literally see an image HTML tag on the page like `<img src='/media/svg-example-1.svg' alt='svg-example-1'>`.

This PR fixes the unwanted behaviour.