### PR TITLE
Wagtail 3 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wagtailsvg",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "repository": "git@github.com:Aleksi44/wagtailsvg.git",
   "author": "Alexis LE BARON <hello@snoweb.fr>",
   "license": "GPL-3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==4.0.2
-wagtail==2.16
+wagtail==3.0.1
 flake8>=3.8.4
-wagtail-generic-chooser==0.3.1
+wagtail-generic-chooser==0.4

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     keywords="wagtail svg",
     license='GPL-3.0',
     install_requires=[
-        'wagtail-generic-chooser==0.3.1'
+        'wagtail-generic-chooser==0.4.0'
     ],
     platforms=['linux'],
     packages=find_packages(),

--- a/tests/blocks.py
+++ b/tests/blocks.py
@@ -1,7 +1,11 @@
 import requests
 from io import BytesIO
 from django.core.files.images import ImageFile
-from wagtail.core.blocks import RichTextBlock
+
+try:
+    from wagtail.blocks import RichTextBlock
+except ImportError:
+    from wagtail.core.blocks import RichTextBlock
 
 from wagtailsvg.models import Svg
 from wagtailsvg.blocks import SvgChooserBlock

--- a/tests/management/commands/init.py
+++ b/tests/management/commands/init.py
@@ -2,8 +2,12 @@ import json
 from django.contrib.auth.models import Group, User
 from django.core.management.base import BaseCommand
 from django.contrib.contenttypes.models import ContentType
-from wagtail.core.models import Page, Site
 from wagtailsvg.models import Svg
+
+try:
+    from wagtail.models import Page, Site
+except ImportError:
+    from wagtail.core.models import Page, Site
 
 from tests.models import TestPage
 from tests.blocks import TextBlock, SvgBlock

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,13 @@
 from django.db import models
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Page
-from wagtail.admin.edit_handlers import StreamFieldPanel
+
+try:
+    from wagtail.fields import StreamField
+    from wagtail.models import Page
+    from wagtail.admin.panels import FieldPanel as StreamFieldPanel
+except:
+    from wagtail.core.fields import StreamField
+    from wagtail.core.models import Page
+    from wagtail.admin.edit_handlers import StreamFieldPanel
 
 from wagtailsvg.edit_handlers import SvgChooserPanel
 from wagtailsvg.models import Svg

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,7 +4,7 @@ try:
     from wagtail.fields import StreamField
     from wagtail.models import Page
     from wagtail.admin.panels import FieldPanel as StreamFieldPanel
-except:
+except ImportError:
     from wagtail.core.fields import StreamField
     from wagtail.core.models import Page
     from wagtail.admin.edit_handlers import StreamFieldPanel

--- a/urls.py
+++ b/urls.py
@@ -3,7 +3,11 @@ from django.urls import include, path
 from django.contrib import admin
 from django.conf.urls.static import static
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+
+try:
+    from wagtail import urls as wagtail_urls
+except ImportError:
+    from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/wagtailsvg/blocks.py
+++ b/wagtailsvg/blocks.py
@@ -1,6 +1,10 @@
 from django.utils.functional import cached_property
 from django.utils.html import format_html
-from wagtail.core.blocks import ChooserBlock
+
+try:
+    from wagtail.blocks import ChooserBlock
+except ImportError:
+    from wagtail.core.blocks import ChooserBlock
 
 
 class SvgChooserBlock(ChooserBlock):

--- a/wagtailsvg/edit_handlers.py
+++ b/wagtailsvg/edit_handlers.py
@@ -1,12 +1,23 @@
 try:
-    from wagtail.admin.panels import BaseChooserPanel
+    from wagtail.admin.panels import FieldPanel
+    from wagtailsvg.widgets import AdminSvgChooser
+
+
+    class SvgChooserPanel(FieldPanel):
+        def __init__(self, field_name, disable_comments=None, permission=None, **kwargs):
+            super().__init__(field_name, **kwargs)
+            self.widget = AdminSvgChooser
+            self.disable_comments = disable_comments
+            self.permission = permission
+
 except ImportError:
     from wagtail.admin.edit_handlers import BaseChooserPanel
 
 
-class SvgChooserPanel(BaseChooserPanel):
-    object_type_name = "svg"
+    class SvgChooserPanel(BaseChooserPanel):
+        object_type_name = "svg"
 
-    def widget_overrides(self):
-        from wagtailsvg.widgets import AdminSvgChooser
-        return {self.field_name: AdminSvgChooser}
+        def widget_overrides(self):
+            from wagtailsvg.widgets import AdminSvgChooser
+            return {self.field_name: AdminSvgChooser}
+

--- a/wagtailsvg/edit_handlers.py
+++ b/wagtailsvg/edit_handlers.py
@@ -1,4 +1,7 @@
-from wagtail.admin.edit_handlers import BaseChooserPanel
+try:
+    from wagtail.admin.panels import BaseChooserPanel
+except ImportError:
+    from wagtail.admin.edit_handlers import BaseChooserPanel
 
 
 class SvgChooserPanel(BaseChooserPanel):

--- a/wagtailsvg/models.py
+++ b/wagtailsvg/models.py
@@ -3,11 +3,18 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
-from wagtail.core.models import CollectionMember
-from wagtail.admin.edit_handlers import TabbedInterface
 from wagtail.search import index
-from wagtail.admin.edit_handlers import ObjectList
-from wagtail.admin.edit_handlers import FieldPanel
+
+try:
+    from wagtail.models import CollectionMember
+    from wagtail.admin.panels import TabbedInterface
+    from wagtail.admin.panels import ObjectList
+    from wagtail.admin.panels import FieldPanel
+except ImportError:
+    from wagtail.core.models import CollectionMember
+    from wagtail.admin.edit_handlers import TabbedInterface
+    from wagtail.admin.edit_handlers import ObjectList
+    from wagtail.admin.edit_handlers import FieldPanel
 
 from taggit.managers import TaggableManager
 

--- a/wagtailsvg/wagtail_hooks.py
+++ b/wagtailsvg/wagtail_hooks.py
@@ -2,7 +2,12 @@ from wagtail.contrib.modeladmin.options import (
     ModelAdmin,
     modeladmin_register
 )
-from wagtail.core import hooks
+
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
+
 from wagtail.admin.site_summary import SummaryItem
 from wagtailsvg.views import SvgChooserViewSet
 from wagtailsvg.models import Svg


### PR DESCRIPTION
Implemented upgrade steps described here: https://docs.wagtail.org/en/stable/releases/3.0.html#upgrade-considerations-deprecation-of-old-functionality

The update checker also told me that the [0001_initial.py](https://github.com/Aleksi44/wagtailsvg/blob/master/wagtailsvg/migrations/0001_initial.py) has one change needed to be done. I did not touch the migration yet since I'm uncertain what's the best way to fix this complaint.

The package still seems to work fine with wagtail 3 without the update since the old paths still re-import all the classes, panels, etc. from the new paths. So I guess there is no need to rush this update if you want to test it first thouroughly.