### PR TITLE
fix instruction to add wagtailsvg to django apps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Install with pip :
 
 ``pip install wagtailsvg``
 
-Add wagtailsvg to django apps installed :
+Add these to django apps installed :
 
 .. code-block:: python
 


### PR DESCRIPTION
The like 
> Add wagtailsvg to django apps installed :
implies that only wagtailsvg needs to be added, when the other two are also required