### PR TITLE
Updates for wagtail 6.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Add these to django apps installed :
 
     INSTALLED_APPS = [
         'wagtailsvg',
-        'wagtail.contrib.modeladmin',
+        'wagtail_modeladmin',
         'generic_chooser',
         ...
     ]

--- a/conf/django.py
+++ b/conf/django.py
@@ -33,7 +33,7 @@ INSTALLED_APPS = [
     'wagtail',
     'wagtail.contrib.settings',
     'wagtail.contrib.frontend_cache',
-    'wagtail.contrib.modeladmin',
+    'wagtail_modeladmin',
     'taggit',
     'generic_chooser',
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     keywords="wagtail svg",
     license='GPL-3.0',
     install_requires=[
-        'wagtail-generic-chooser==0.5.1'
+        'wagtail-generic-chooser>=0.5.1',
+        'wagtail-modeladmin>=1.0',
     ],
     platforms=['linux'],
     packages=find_packages(),

--- a/wagtailsvg/models.py
+++ b/wagtailsvg/models.py
@@ -11,7 +11,7 @@ try:
     from wagtail.admin.panels import ObjectList
     from wagtail.admin.panels import FieldPanel
 except ImportError:
-    from wagtail.core.models import CollectionMember
+    from wagtail.models import CollectionMember
     from wagtail.admin.edit_handlers import TabbedInterface
     from wagtail.admin.edit_handlers import ObjectList
     from wagtail.admin.edit_handlers import FieldPanel

--- a/wagtailsvg/wagtail_hooks.py
+++ b/wagtailsvg/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from wagtail.contrib.modeladmin.options import (
+from wagtail_modeladmin.options import (
     ModelAdmin,
     modeladmin_register
 )


### PR DESCRIPTION
This pull request includes:

- replace `wagtail.contrib.modeladmin` with `wagtail_modeladmin` and updating the imports to use the new Wagtail module paths.

Dependency updates:

* [`README.rst`](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL59-R59): Replaced `wagtail.contrib.modeladmin` with `wagtail_modeladmin` in the `INSTALLED_APPS` list.
* [`conf/django.py`](diffhunk://#diff-9a8f11573ac7be829bf1bfd36bfae661c51bb7f6dc6743ea9d9405a64cf779f5L36-R36): Replaced `wagtail.contrib.modeladmin` with `wagtail_modeladmin` in the `INSTALLED_APPS` list.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L26-R27): Updated `wagtail-generic-chooser` to version `>=0.5.1` and added `wagtail-modeladmin` with version `>=1.0` to the `install_requires` list.

Import updates:

* [`wagtailsvg/models.py`](diffhunk://#diff-49b7605eb5c71ac6984a32f3ba3506906db21994ca2c8e3e4a00fa0b08dc3fbfL14-R14): Updated import from `wagtail.core.models` to `wagtail.models` for `CollectionMember`.
* [`wagtailsvg/wagtail_hooks.py`](diffhunk://#diff-2d8aa63b079951d88deaeccbb15a59eeed5044ad1b4f9b87da60385af37c7349L1-R1): Replaced import from `wagtail.contrib.modeladmin.options` with `wagtail_modeladmin.options` for `ModelAdmin` and `modeladmin_register`.